### PR TITLE
Changing paginator code to work with latest version of hugo

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 {{ $baseurl := .Site.BaseURL }}
 
 <!-- Posts -->
-{{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+{{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") }}
 {{ range $paginator.Pages }}
 <div class="row">
 	<div class="twelve column">


### PR DESCRIPTION
Hugo made a change in 0.57 that breaks code that uses paginators like this. This changes it so that you can build this theme with 0.57 and above. See https://github.com/pacollins/hugo-future-imperfect-slim/issues/68 as an example.